### PR TITLE
Enable testing with ctest.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,19 @@
-cmake_minimum_required(VERSION 3.12)
-project(blist)
+PROJECT(blist)
 
-set(CMAKE_CXX_STANDARD 14)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
+SET(CMAKE_CXX_STANDARD 14)
 
-SET(lib_SRCS
-        libsrc/File.cc
-        libsrc/FileName.cc
-        libsrc/fileutil.cc
-        libsrc/proginfo.cc
-        libsrc/TextBox.cc
-        libsrc/utildbug.cc
-        libsrc/utilmsg.cc
-        )
-SET(lib_HDRS
-        libsrc/File.h
-        libsrc/FileName.h
-        libsrc/fileutil.h
-        libsrc/proginfo.h
-        libsrc/TextBox.h
-        libsrc/utildbug.h
-        libsrc/utilmsg.h
-        )
+FILE(GLOB lib_SRCS CONFIGURE_DEPENDS "libsrc/*.cc")
+
+FILE(GLOB lib_HDRS CONFIGURE_DEPENDS "libsrc/*.h")
 
 SET(blist_SRCS main.cc blist.cc blist.h)
 
 ADD_LIBRARY(mylib STATIC ${lib_HDRS} ${lib_SRCS})
-add_executable(blist ${blist_SRCS} ${lib_HDRS} ${lib_SRCS})
+ADD_EXECUTABLE(blist ${blist_SRCS} ${lib_HDRS} ${lib_SRCS})
 
-install(TARGETS blist RUNTIME DESTINATION bin)
+ENABLE_TESTING()
+
+ADD_TEST(blist_exe blist ../blist.h)
+
+INSTALL(TARGETS blist RUNTIME DESTINATION bin)

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+cmake -S . -B _build && cmake --build _build

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+pushd _build && ctest


### PR DESCRIPTION
- Enable testing with `ctest`, using a simple program execution.

- Use file-glob for `libsrc` files, rather than needing explicit filenames.

- Add `build.sh` and `test.sh` scripts for easier command line build/test runs.