### PR TITLE
Separate TraceEntryExit class.

### DIFF
--- a/blist.cc
+++ b/blist.cc
@@ -8,9 +8,9 @@
 #include <getopt.h>
 
 #include "libsrc/proginfo.h"
-#include "libsrc/utildbug.h"
 #include "libsrc/File.h"
 #include "libsrc/TextBox.h"
+#include "libsrc/TraceEntryExit.h"
 
 #include "blist.h"
 
@@ -51,7 +51,7 @@ void ShowUsage() {
  * @return TRUE if there were no errors found when parsing command line arguments.
  */
 bool ParseArguments(int argc, char *const *argv, blist_params &params) {
-  const std::string& ProgName = ProgInfo::Name;
+  const std::string &ProgName = ProgInfo::Name;
 
   // Check arguments
   int arg_error_count = 0;
@@ -109,6 +109,7 @@ void ProcessFile(
     File &f,
     const blist_params &params,
     std::ostream &out = std::cout) {
+
   // List this file
   // ==============
 

--- a/libsrc/File.cc
+++ b/libsrc/File.cc
@@ -15,9 +15,9 @@
 #include <sstream>
 #include <vector>
 
-#include "utildbug.h"
 #include "filter.h"
 #include "fileutil.h"
+#include "TraceEntryExit.h"
 
 // End Implementation Dependencies -------------------------------------------
 
@@ -31,7 +31,7 @@
 // End ---------------------------------------------------------------------
 File::File(const std::string &fname, bool log_failures)
     : PathName(fname) {
-  TraceEntryExit t("File", "<constructor>");
+  TraceEntryExit t("File", "<constructor>", fname);
 
   if (!Exists()) {
     // File does not exist
@@ -52,7 +52,7 @@ File::File(const std::string &fname, bool log_failures)
 //
 // End ---------------------------------------------------------------------
 File::~File() {
-  TraceEntryExit t("File", "<destructor>");
+  TraceEntryExit t("File", "<destructor>", this->FullName());
 }
 // End File Destructor //
 

--- a/libsrc/TraceEntryExit.cc
+++ b/libsrc/TraceEntryExit.cc
@@ -1,0 +1,81 @@
+#include <iostream>
+#include <memory>
+
+#include "TraceEntryExit.h"
+
+/*  Initialise static data members of class TraceEntryExit */
+bool TraceEntryExit::logEntryExits = false;
+
+/** Log function entry message. */
+#define TRACE_ENTER(class_name, function_name, args) \
+  std::clog << EntryPrefix << class_name << "::" << function_name; \
+  if (!args.empty()) std::clog << " - " << args; \
+  std::clog << "\n"; // Stream flush not required, so don't use std::endl
+
+/** Log function exit message. */
+#define TRACE_EXIT(class_name, function_name, args) \
+  std::clog << Exit_Prefix << class_name << "::" << function_name; \
+  if (!args.empty()) std::clog << " - " << args; \
+  std::clog << "\n"; // Stream flush not required, so don't use std::endl
+
+TraceEntryExit::TraceEntryExit(
+    const std::string &class_name,
+    const std::string &function_name,
+    bool always_log)
+    : TraceEntryExit(class_name, function_name, BLANK_STR, always_log) {
+}
+
+TraceEntryExit::TraceEntryExit(
+    const std::string &class_name,
+    const std::string &function_name,
+    const std::string &arguments,
+    bool always_log)
+    : className(class_name), functionName(function_name), args(arguments), alwaysLog(always_log) {
+  if (alwaysLog || logEntryExits) {
+    TRACE_ENTER(this->className, this->functionName, this->args);
+  }
+}
+
+TraceEntryExit::TraceEntryExit(
+    const char *class_name,
+    const char *function_name,
+    bool always_log)
+    : TraceEntryExit(class_name, function_name, BLANK, always_log) {
+}
+
+TraceEntryExit::TraceEntryExit(
+    const char *class_name,
+    const char *function_name,
+    const char *arguments,
+    bool always_log)
+    : TraceEntryExit(
+    *(std::make_unique<std::string>(class_name).get()),
+    *(std::make_unique<std::string>(function_name).get()),
+    *(std::make_unique<std::string>(arguments).get()),
+    always_log) {
+}
+
+TraceEntryExit::~TraceEntryExit() {
+  if (alwaysLog || logEntryExits) {
+    TRACE_EXIT(this->className, this->functionName, this->args);
+  }
+}
+
+bool TraceEntryExit::SetLogging(bool new_trace_level) {
+  bool old_logEntryExits = logEntryExits;
+  logEntryExits = new_trace_level;
+  return old_logEntryExits;
+}
+
+TraceLevelOverride TraceLevelOverride::SetLogging(bool new_trace_level) {
+  bool old_trace_level = TraceEntryExit::SetLogging(new_trace_level);
+  return TraceLevelOverride(old_trace_level);
+}
+
+TraceLevelOverride::TraceLevelOverride(bool old_trace_level)
+    : previous(old_trace_level) {
+}
+
+TraceLevelOverride::~TraceLevelOverride() {
+  TraceEntryExit::SetLogging(this->previous);
+}

--- a/libsrc/TraceEntryExit.h
+++ b/libsrc/TraceEntryExit.h
@@ -1,0 +1,109 @@
+#ifndef TRACE_ENTRY_EXIT_H
+#define TRACE_ENTRY_EXIT_H
+
+#include <string>
+
+static const char *BLANK = "";
+static const std::string BLANK_STR = std::string(BLANK);
+
+/**
+ * Class: TraceLevelOverride
+ * =========================
+ * A RAII (Resource Acquisition Is Initialization) / aka lifetime control ("Destruction is Resource Relinquishment")
+ * class to allow temporarily override the tracing level.
+ */
+class TraceLevelOverride {
+private:
+  bool previous;
+
+public:
+  static TraceLevelOverride SetLogging(bool new_trace_level);
+
+  explicit TraceLevelOverride(bool old_trace_level);
+
+  virtual ~TraceLevelOverride();
+};
+
+/**
+ * Class: TraceEntryExit
+ * =====================
+ * Provides entry and exit tracing facilities.
+ *
+ * When the destructor is called for an object of this class,
+ *  an appropriate message will be logged to the stream std::clog stream
+ *  if the flag `logEntryExits` is set.
+ */
+class TraceEntryExit {
+private:
+  static bool logEntryExits; // If true, then entry and exit trace will be logged.
+
+  const std::string &className;
+  const std::string &functionName;
+  const std::string &args;
+
+  bool alwaysLog;
+
+public:
+  constexpr static const char *EntryPrefix = ">>>> Enter ";
+  constexpr static const char *Exit_Prefix = "<<<< Exit_ ";
+
+  /**
+   * Constructor: TraceEntryExit
+   * @param class_name - Class name.
+   * @param function_name - Function name.
+   * @param always_log - Override the logEntryExists flag for this trace object.
+   */
+  TraceEntryExit(
+      const std::string &class_name,
+      const std::string &function_name,
+      bool always_log = false);
+
+  /**
+   * Constructor: TraceEntryExit
+   * @param class_name - Class name.
+   * @param function_name - Function name.
+   * @param arguments - Function arguments info, if any.
+   * @param always_log - Override the logEntryExists flag for this trace object.
+   */
+  TraceEntryExit(
+      const std::string &class_name,
+      const std::string &function_name,
+      const std::string &arguments,
+      bool always_log = false);
+
+  /**
+   * Constructor: TraceEntryExit
+   * @param class_name - Class name.
+   * @param function_name - Function name.
+   * @param always_log - Override the logEntryExists flag for this trace object.
+   */
+  TraceEntryExit(
+      const char *class_name,
+      const char *function_name,
+      bool always_log = false);
+
+  /**
+   * Constructor: TraceEntryExit
+   * @param class_name - Class name.
+   * @param function_name - Function name.
+   * @param arguments - Function arguments info, if any.
+   * @param always_log - Override the logEntryExists flag for this trace object.
+   */
+  TraceEntryExit(
+      const char *class_name,
+      const char *function_name,
+      const char *arguments,
+      bool always_log = false);
+
+  /**
+   * Destructor: ~TraceEntryExit
+   * Destroys the object,
+   *  and may or may not display the exit message,
+   *  depending on the value of the `logEntryExits` variable.
+   */
+  ~TraceEntryExit();
+
+  static bool SetLogging(bool new_trace_level);
+};
+
+#endif //TRACE_ENTRY_EXIT_H

--- a/libsrc/utildbug.cc
+++ b/libsrc/utildbug.cc
@@ -7,46 +7,6 @@
 
 constexpr int MAX_LINE_SIZE = 132;
 
-/*  Initialise static data members of class TraceEntryExit */
-std::string TraceEntryExit::EntryPrefix = ">>>> Entering ";
-std::string TraceEntryExit::ExitPrefix = "<<<< Exiting  ";
-bool TraceEntryExit::logEntryExits = false;
-
-// Description -------------------------------------------------------------
-//
-// Constructor: TraceEntryExit
-//
-// End ---------------------------------------------------------------------
-TraceEntryExit::TraceEntryExit(
-    const std::string &class_name,
-    const std::string &function_name)
-    : className(class_name), functionName(function_name) {
-  if (logEntryExits) {
-    // Log entry message
-    std::clog << TraceEntryExit::EntryPrefix
-              << className << "::" << functionName << std::endl;
-  }
-}
-// End Constructor //
-
-
-// Description -------------------------------------------------------------
-//
-// Destructor: ~TraceEntryExit
-//	Destroys the object, and may or may not display the exit message
-//	 depending on the value of the logEntryExits variable.
-//
-// End ---------------------------------------------------------------------
-TraceEntryExit::~TraceEntryExit() {
-  if (logEntryExits) {
-    // Log entry message
-    std::clog << TraceEntryExit::ExitPrefix
-              << className << "::" << functionName << std::endl;
-  }
-}
-// End Destructor //
-
-
 /***************************************** commented out starts *************
 static  ostream_withassign  debug_dest;
 

--- a/libsrc/utildbug.h
+++ b/libsrc/utildbug.h
@@ -97,37 +97,6 @@ extern ofstream errlog;
 /* Function Entry and Exit tracing                                           */
 /*****************************************************************************/
 
-// Description -------------------------------------------------------------
-//
-// Class: TraceEntryExit
-//	Provides entry and exit tracing facilities.
-//	When the destructor is called for an object of this class, an
-//	 appropriate message will be logged to the stream clog if
-//	 logEntryExits is TRUE.
-//
-// End ---------------------------------------------------------------------
-class TraceEntryExit {
-private:
-  static std::string EntryPrefix;
-  static std::string ExitPrefix;
-
-  static bool logEntryExits; // If true, then entry and exit trace will be logged.
-
-  const std::string &className;
-  const std::string &functionName;
-public:
-  TraceEntryExit(
-      const std::string &className,
-      const std::string &functionName);
-
-  ~TraceEntryExit();
-
-  static void SetLogging(bool bLogTrace) {
-    TraceEntryExit::logEntryExits = bLogTrace;
-  };
-};
-// End Class TraceEntryExit
-
 
 /* Original RCS change records from DOS version: */
 /******************************************************************************

--- a/tests/lib_tests.cc
+++ b/tests/lib_tests.cc
@@ -4,17 +4,27 @@
 #include "gtest/gtest.h"
 
 #include "../libsrc/proginfo.h"
-#include "../libsrc/utildbug.h"
 #include "../libsrc/File.h"
 #include "../libsrc/FileName.h"
 #include "../libsrc/TextBox.h"
+#include "../libsrc/TraceEntryExit.h"
 
 #define DEBUG
 
-TEST(lib_tests, File) {
-  TraceEntryExit t("lib_tests", "File test");
+TEST(lib_tests, TraceLevelOverride) {
+  {
+    auto trace_override = TraceLevelOverride::SetLogging(true);
+    TraceEntryExit t("lib_tests", "TraceEntryExit_test_on");
+  }
 
-  std::cout << "Start File test" << std::endl;
+  {
+    auto trace_override = TraceLevelOverride::SetLogging(false);
+    TraceEntryExit t("lib_tests", "TraceEntryExit_test_off");
+  }
+}
+
+TEST(lib_tests, File) {
+  TraceEntryExit t("lib_tests", "File", true);
 
   File file("cmake_install.cmake");
   File none("no-file.non", false);  // Non-existent file
@@ -25,33 +35,22 @@ TEST(lib_tests, File) {
   std::cout << file.FullName() << std::endl << file << std::endl;
 
   std::cout << none.FName() << std::endl << none << std::endl;
-
-  std::cout << "End File test" << std::endl;
 }
 
-TEST(lib_tests, FileName_Exists) {
-  TraceEntryExit t("lib_tests", "FileName_Exists test");
+TEST(lib_tests, FilePath_Exists) {
+  TraceEntryExit t("lib_tests", "FilePath_Exists", true);
 
-  std::cout << "Start FileName test" << std::endl;
-
-  FileName file("cmake_install.cmake");
   FileName none("no-file.non");  // Non-existent file
-
-  std::cout << "file : " << file << " Exists = " << file.Exists() << std::endl;
-  EXPECT_TRUE(file.Exists()) << file.to_string() << " should exist.";
-
   std::cout << "none : " << none << " Exists = " << none.Exists() << std::endl;
   EXPECT_FALSE(none.Exists()) << none.to_string() << " should not exist.";
 
-  file = PathName(file);
-  std::cout << "path(file) : " << file << " Exists = " << file.Exists() << std::endl;
+  FileName file("cmake_install.cmake");
+  std::cout << "file : " << file << " Exists = " << file.Exists() << std::endl;
   EXPECT_TRUE(file.Exists()) << file.to_string() << " should exist.";
-
-  std::cout << "End FileName test" << std::endl;
 }
 
-TEST(lib_tests, PathName_Split) {
-  TraceEntryExit t("lib_tests", "PathName_Split test");
+TEST(lib_tests, FilePath_Path_Split) {
+  TraceEntryExit t("lib_tests", "FilePath_Path_Split", true);
 
   auto current_dir = PathName::GetCurrentDirectory();
 
@@ -63,11 +62,9 @@ TEST(lib_tests, PathName_Split) {
 }
 
 TEST(lib_tests, TextBox) {
-  TraceEntryExit t("lib_tests", "TextBox test");
+  TraceEntryExit t("lib_tests", "TextBox", true);
 
   std::vector<std::string> multi_line = {"Line1", "Line2", "Line3", "Last Line"};
-
-  std::cout << "Start TextBox test" << std::endl;
 
   std::cout << TextBox("Text in a box");
 
@@ -76,8 +73,6 @@ TEST(lib_tests, TextBox) {
   std::cout << TextBox("Even more text in an X-box", TextBox::DOUBLE, 'X');
 
   std::cout << TextBox(multi_line, TextBox::STANDARD);
-
-  std::cout << "End TextBox test" << std::endl;
 }
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
- Separate `TraceEntryExit` class into its own file.

- Add `TraceLevelOverride` class to allow temporary set / reset of trace levels.

- Add (optional) args printing to `TraceEntryExit`.