### PR TITLE
Filter::main_loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(blist_SRCS main.cc blist.cc blist.h)
 ADD_LIBRARY(mylib STATIC ${lib_HDRS} ${lib_SRCS})
 ADD_EXECUTABLE(blist ${blist_SRCS} ${lib_HDRS} ${lib_SRCS})
 ADD_EXECUTABLE(test_filter test_filter.cc
-        libsrc/filter.h
+        libsrc/filter.h libsrc/filter.cc
         libsrc/FilePath.h libsrc/FilePath.cc
         libsrc/fileutil.h libsrc/fileutil.cc)
 

--- a/libsrc/File.cc
+++ b/libsrc/File.cc
@@ -146,7 +146,7 @@ void File::PrintOn(std::ostream &s) {
     // Copy file contents to output stream
     std::ifstream file_reader(this->FullName());
     FilePrinter pr(file_reader, s);
-    main_loop(&pr); /* Iterate */
+    pr.main_loop(); /* Iterate */
   } else {
     std::cerr << "File " << this->FullName() << " does not exist, so no output." << std::endl;
   }

--- a/libsrc/filter.cc
+++ b/libsrc/filter.cc
@@ -1,0 +1,43 @@
+// _LIBCPP_NO_EXCEPTIONS will be defined if the C++ compiler does not support Exceptions.
+
+#include "filter.h"
+
+/**
+ * Function main_loop (using Exceptions unless _LIBCPP_NO_EXCEPTIONS is defined)
+ * @return
+ */
+int IFilter::main_loop() {
+  IFilter *p = this;
+
+  for (;;)  // Loop forever, until breakout condition is hit.
+  {
+
+#ifndef _LIBCPP_NO_EXCEPTIONS
+    try {
+#endif // _LIBCPP_NO_EXCEPTIONS
+
+      p->start();
+      while (p->read()) {
+        p->compute();
+        p->write();
+      }
+      return p->result();  // Exit loop
+
+#ifndef _LIBCPP_NO_EXCEPTIONS
+    }
+    catch (IFilter::ERetry &m) {
+      std::cerr << m.message() << std::endl;
+      int i = p->retry();
+      if (i) {
+        return -i;  // Exit loop
+      }
+    }
+    catch (...) {
+      std::cerr << "ERROR: Fatal filter error" << std::endl;
+      return -10;  // Exit loop
+    }
+#endif // _LIBCPP_NO_EXCEPTIONS
+
+  } // End forever loop
+  // Not reached.
+}

--- a/libsrc/filter.h
+++ b/libsrc/filter.h
@@ -1,8 +1,6 @@
 #ifndef _FILTER_H
 #define _FILTER_H
 
-// Use  CC -DNEXCEPTIONS ....   if the C++ compiler does not support Exceptions.
-
 #ifndef __cplusplus
 #error Requires C++ for use of these facilities
 #endif
@@ -40,44 +38,10 @@ public:
   virtual int result() { return 0; };
 
   virtual ~IFilter() = default;
+
+  int main_loop();
 };
 // End class IFilter
-
-
-// Function main_loop (using Exceptions unless NEXCEPTIONS is defined)
-int main_loop(IFilter *p) {
-  for (;;)  // Loop forever
-  {
-
-#ifndef NEXCEPTIONS
-    try {
-#endif /* NEXCEPTIONS */
-
-      p->start();
-      while (p->read()) {
-        p->compute();
-        p->write();
-      }
-      return p->result();  // Exit loop
-
-#ifndef NEXCEPTIONS
-    }
-    catch (IFilter::ERetry &m) {
-      std::cerr << m.message() << std::endl;
-      int i = p->retry();
-      if (i) {
-        return -i;  // Exit loop
-      }
-    }
-    catch (...) {
-      std::cerr << "Fatal filter error" << std::endl;
-      return -10;  // Exit loop
-    }
-#endif /* NEXCEPTIONS */
-
-  } // End forever loop
-  // Not reached.
-}
 
 
 /*******************************************************************************
@@ -161,6 +125,27 @@ public:
 };
 // End class ILineStreamFilter
 
+class LineCounter : public ILineStreamFilter {
+  int num_lines;
+public:
+  void compute() override { num_lines++; };
+
+  int result() override { return num_lines; };
+
+  explicit LineCounter(std::istream &ii)
+      : ILineStreamFilter(ii), num_lines(0) {}
+};
+
+class CharCounter : public ICharStreamFilter {
+  int num_chars;
+public:
+  void compute() override { num_chars++; };
+
+  int result() override { return num_chars; };
+
+  explicit CharCounter(std::istream &ii)
+      : ICharStreamFilter(ii), num_chars(0) {}
+};
 
 /*******************************************************************************
  Change History

--- a/test_filter.cc
+++ b/test_filter.cc
@@ -6,37 +6,6 @@
 #include <iostream>
 #include <memory>
 
-class FileCharCounter : public ICharStreamFilter {
-  int num_chars;
-public:
-  void compute() override { num_chars++; };
-
-  int result() override {
-    std::cout << num_chars << " characters read" << std::endl;
-    return 0;
-  };
-
-  explicit FileCharCounter(std::istream &ii)
-      : ICharStreamFilter(ii), num_chars(0) {}
-};
-// End class FileCharCounter
-
-class FileLineCounter : public ILineStreamFilter {
-  int num_lines;
-public:
-  void compute() override { num_lines++; };
-
-  int result() override {
-    std::cout << num_lines << " lines read" << std::endl;
-    return 0;
-  };
-
-  explicit FileLineCounter(std::istream &ii)
-      : ILineStreamFilter(ii), num_lines(0) {}
-};
-// End class FileLineCounter
-
-
 int main(int argc, char **argv) {
   bool count_lines = true;
   std::string source;
@@ -48,7 +17,7 @@ int main(int argc, char **argv) {
     std::string file_name = argv[1];
     FilePath input_file(file_name);
     if (!input_file.Exists()) {
-      std::cerr << "test_filter: Input file not found '" << input_file.FullName() << "'." << std::endl;
+      std::cerr << "test_filter: ERROR: Input file not found '" << input_file.FullName() << "'." << std::endl;
       return -1;
     }
     p_input_stream = std::make_unique<std::ifstream>(file_name).get();
@@ -57,18 +26,24 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<IFilter> counter;
   if (count_lines) {
-    std::cerr << "test_filter: Read from " << source << " and count lines." << std::endl;
-    counter = std::make_unique<FileLineCounter>(*p_input_stream);
+    std::cerr << "test_filter: Reading from " << source << " and count lines." << std::endl;
+    counter = std::make_unique<LineCounter>(*p_input_stream);
   } else {
-    std::cerr << "test_filter: Read from " << source << " and count characters." << std::endl;
-    counter = std::make_unique<FileCharCounter>(*p_input_stream);
+    std::cerr << "test_filter: Reading from " << source << " and count characters." << std::endl;
+    counter = std::make_unique<CharCounter>(*p_input_stream);
   }
   std::cerr.flush();
   std::cout.flush();
 
-  int rc = main_loop(counter.get());
+  int rc = counter->main_loop();
 
   std::cout.flush();
+
+  if (count_lines) {
+    std::cout << "Read " << counter->result() << " lines from " << source << std::endl;
+  } else {
+    std::cout << "Read " << counter->result() << " chars from " << source << std::endl;
+  }
 
   std::cerr << "Main loop completed with rc = " << rc << std::endl;
 

--- a/tests/file_filter_tests.cc
+++ b/tests/file_filter_tests.cc
@@ -1,0 +1,48 @@
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "cert-err58-cpp"
+
+#include "gtest/gtest.h"
+
+#include <iostream>
+#include <fstream>
+
+#include "../libsrc/filter.h"
+#include "../libsrc/proginfo.h"
+#include "../libsrc/FilePath.h"
+#include "../libsrc/TraceEntryExit.h"
+
+TEST(file_filter_tests, ReadLines) {
+  TraceEntryExit t("file_filter_tests", "ReadLines", true);
+
+  FilePath file("cmake_install.cmake");
+  EXPECT_TRUE(file.Exists()) << file.to_string() << " should exist.";
+
+  auto file_reader = std::make_unique<std::ifstream>(file.FullName());
+  auto counter = std::make_unique<LineCounter>(*file_reader);
+
+  int rc = counter->main_loop();
+
+  std::cout << counter->result() << " lines read" << std::endl;
+
+  EXPECT_GE(counter->result(), 10) << "Should have read some records.";
+  EXPECT_NE(rc, 0) << "Should not have got zero result code.";
+}
+
+TEST(file_filter_tests, ReadChars) {
+  TraceEntryExit t("file_filter_tests", "ReadChars", true);
+
+  FilePath file("cmake_install.cmake");
+  EXPECT_TRUE(file.Exists()) << file.to_string() << " should exist.";
+
+  auto file_reader = std::make_unique<std::ifstream>(file.FullName());
+  auto counter = std::make_unique<CharCounter>(*file_reader);
+
+  int rc = counter->main_loop();
+
+  std::cout << counter->result() << " characters read" << std::endl;
+
+  EXPECT_GE(counter->result(), 1000) << "Should have read some data.";
+  EXPECT_NE(rc, 0) << "Should not have got zero result code.";
+}
+
+#pragma clang diagnostic pop


### PR DESCRIPTION
Reusable main_loop function.

Add test case for `IFilter::main_loop`

Use the standard _LIBCPP_NO_EXCEPTIONS flag to disable exceptions.