### PR TITLE
blist-TextBox

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ PROJECT(blist)
 FILE(GLOB lib_SRCS CONFIGURE_DEPENDS "libsrc/*.cc")
 FILE(GLOB lib_HDRS CONFIGURE_DEPENDS "libsrc/*.h")
 
-SET(blist_SRCS main.cc blist.cc blist.h)
+SET(blist_SRCS blist.cc blist.h)
 
 ADD_LIBRARY(mylib STATIC ${lib_HDRS} ${lib_SRCS})
 ADD_EXECUTABLE(blist ${blist_SRCS} ${lib_HDRS} ${lib_SRCS})

--- a/blist.cc
+++ b/blist.cc
@@ -117,7 +117,7 @@ void ProcessFile(
   const auto file_info = f.FileInfo();
 
   // Output file header
-  out << TextBox(file_info, TextBox::STANDARD);
+  out << TextBox(file_info, TextBox::BASIC);
 
   out << NL;  // Blank line
 
@@ -170,6 +170,10 @@ int blist_main(int argc, char **argv) {
   exit(0);
 }
 
+int main(int argc, char *argv[]) {
+  int rc = blist_main(argc, argv);
+  return rc;
+}
 
 /******************************************************************************
  Change History

--- a/libsrc/TextBox.cc
+++ b/libsrc/TextBox.cc
@@ -140,21 +140,27 @@ TextBox::~TextBox() {
 std::ostream &operator<<(std::ostream &s, const TextBox &tb) {
   size_t text_len = 0;
   char *p;
-  unsigned int l;
+  size_t l;
   int border_width;
-  int gap_width;
+  int hgap_width;
+  int vgap_width;
 
   const char EOL = '\n';
   const char SPACE = ' ';
 
   // Decide border and gap widths
   if (tb.box_type == TextBox::DOUBLE) {
-    border_width = gap_width = 2;
+    border_width = 2;
+    hgap_width = 2;
+    vgap_width = 1;
   } else if (tb.box_type == TextBox::BASIC) {
     border_width = 1;
-    gap_width = 0;
+    hgap_width = 1;
+    vgap_width = 0;
   } else {
-    border_width = gap_width = 1;
+    border_width = 1;
+    hgap_width = 1;
+    vgap_width = 1;
   }
 
   // Decide on the length of the longest line in the textbox.
@@ -166,15 +172,15 @@ std::ostream &operator<<(std::ostream &s, const TextBox &tb) {
 
   // Top border
   for (auto j = 1; j <= border_width; j++) {
-    for (size_t i = 1; i <= (text_len + 2 * border_width + 2 * gap_width); i++) {
+    for (size_t i = 1; i <= (text_len + 2 * border_width + 2 * hgap_width); i++) {
       s << tb.box_char;
     }
     s << EOL;
   }
   // Top gap
-  for (auto j = 1; j <= gap_width; j++) {
+  for (auto j = 1; j <= vgap_width; j++) {
     for (auto i = 1; i <= border_width; i++) { s << tb.box_char; }
-    for (size_t i = 1; i <= text_len + 2 * gap_width; i++) { s << SPACE; }
+    for (size_t i = 1; i <= text_len + 2 * hgap_width; i++) { s << SPACE; }
     for (auto i = 1; i <= border_width; i++) { s << tb.box_char; }
     s << EOL;
   }
@@ -182,27 +188,27 @@ std::ostream &operator<<(std::ostream &s, const TextBox &tb) {
   // Output each line of the text message
   for (l = 0, p = tb.text; l < tb.num_lines; l++, p += strlen(p) + 1) {
     for (auto i = 1; i <= border_width; i++) { s << tb.box_char; }
-    for (auto i = 1; i <= gap_width; i++) { s << SPACE; }
+    for (auto i = 1; i <= hgap_width; i++) { s << SPACE; }
 
     // Output this line of the text left justified in a field
     // big enough to take the longest line in the TextBox.
     s << std::setw(static_cast<int>(text_len)) << std::setiosflags(std::ios::left) << p;
 
-    for (auto i = 1; i <= gap_width; i++) { s << SPACE; }
+    for (auto i = 1; i <= hgap_width; i++) { s << SPACE; }
     for (auto i = 1; i <= border_width; i++) { s << tb.box_char; }
     s << EOL;
   }
 
   // Bottom gap
-  for (auto j = 1; j <= gap_width; j++) {
+  for (auto j = 1; j <= vgap_width; j++) {
     for (auto i = 1; i <= border_width; i++) { s << tb.box_char; }
-    for (size_t i = 1; i <= text_len + 2 * gap_width; i++) { s << SPACE; }
+    for (size_t i = 1; i <= text_len + 2 * hgap_width; i++) { s << SPACE; }
     for (auto i = 1; i <= border_width; i++) { s << tb.box_char; }
     s << EOL;
   }
   // Bottom border
   for (auto j = 1; j <= border_width; j++) {
-    for (size_t i = 1; i <= (text_len + 2 * border_width + 2 * gap_width); i++) {
+    for (size_t i = 1; i <= (text_len + 2 * border_width + 2 * hgap_width); i++) {
       s << tb.box_char;
     }
     s << EOL;

--- a/main.cc
+++ b/main.cc
@@ -1,6 +1,0 @@
-#include "blist.h"
-
-int main(int argc, char *argv[]) {
-  int rc = blist_main(argc, argv);
-  return rc;
-}

--- a/tests/lib_tests.cc
+++ b/tests/lib_tests.cc
@@ -82,11 +82,11 @@ TEST(lib_tests, FilePath_Absolute) {
 TEST(lib_tests, TextBox) {
   TraceEntryExit t("lib_tests", "TextBox", true);
 
-  std::vector<std::string> multi_line = {"Line1", "Line2", "Line3", "Last Line"};
+  std::vector<std::string> multi_line = {"Multiple lines", "Line1", "Line2", "Line3", "Last Line"};
 
-  std::cout << TextBox("Text in a box");
+  std::cout << TextBox("Text in a box", TextBox::BASIC);
 
-  std::cout << TextBox("More text in a box", TextBox::STANDARD);
+  std::cout << TextBox("More text in a bigger box", TextBox::STANDARD);
 
   std::cout << TextBox("Even more text in an X-box", TextBox::DOUBLE, 'X');
 


### PR DESCRIPTION
- Allow separate horizontal and vertical gap distances around TextBox contents.

- Use `BASIC` header box for blist output.