### PR TITLE
file_filter.exe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       run: |
         cmake --version
         cmake --help
+        gcc --version
     - name: List build files
       run: |
         echo "Current User" && id

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ SET(blist_SRCS blist.cc blist.h)
 
 ADD_LIBRARY(mylib STATIC ${lib_HDRS} ${lib_SRCS})
 ADD_EXECUTABLE(blist ${blist_SRCS} ${lib_HDRS} ${lib_SRCS})
-ADD_EXECUTABLE(test_filter test_filter.cc
+ADD_EXECUTABLE(file_filter file_filter.cc
         libsrc/filter.h libsrc/filter.cc
         libsrc/FilePath.h libsrc/FilePath.cc
         libsrc/fileutil.h libsrc/fileutil.cc)
@@ -57,10 +57,10 @@ TARGET_LINK_LIBRARIES(blist_test gtest_main)
 
 ADD_TEST(run_blist_tests blist_test)
 
-ADD_TEST(run_blist_exe blist ${PROJECT_SOURCE_DIR}/blist.h)
+ADD_TEST(run_blist_exe blist "${PROJECT_SOURCE_DIR}/blist.h")
 
 ## Test step disabled 2019-08-22 - Causes SegFault when running on GitHub Actions build servers.
-## ADD_TEST(run_filter_exe test_filter ${CMAKE_SOURCE_DIR}/blist.h)
+## ADD_TEST(run_filter_exe file_filter "${PROJECT_SOURCE_DIR}/blist.h")
 
 # Install
 

--- a/file_filter.cc
+++ b/file_filter.cc
@@ -2,11 +2,14 @@
 #include "libsrc/filter.h"
 #include "libsrc/FilePath.h"
 
+#include <exception>
 #include <fstream>
 #include <iostream>
 #include <memory>
 
-int main(int argc, char **argv) {
+std::string prog_name = "file_filter";
+
+int file_filter_main(int argc, char **argv) {
   bool count_lines = true;
   std::string source;
   std::istream *p_input_stream = nullptr;
@@ -17,19 +20,19 @@ int main(int argc, char **argv) {
     std::string file_name = argv[1];
     FilePath input_file(file_name);
     if (!input_file.Exists()) {
-      std::cerr << "test_filter: ERROR: Input file not found '" << input_file.FullName() << "'." << std::endl;
+      std::cerr << prog_name << ": ERROR: Input file not found '" << input_file.FullName() << "'." << std::endl;
       return -1;
     }
-    p_input_stream = std::make_unique<std::ifstream>(file_name).get();
-    source = "file '" + file_name + "'";
+    p_input_stream = std::make_unique<std::ifstream>(input_file.FullName()).get();
+    source = "file '" + input_file.FullName() + "'";
   }
 
   std::unique_ptr<IFilter> counter;
   if (count_lines) {
-    std::cerr << "test_filter: Reading from " << source << " and count lines." << std::endl;
+    std::cerr <<  prog_name << ": Reading from " << source << " and count lines." << std::endl;
     counter = std::make_unique<LineCounter>(*p_input_stream);
   } else {
-    std::cerr << "test_filter: Reading from " << source << " and count characters." << std::endl;
+    std::cerr <<  prog_name << ": Reading from " << source << " and count characters." << std::endl;
     counter = std::make_unique<CharCounter>(*p_input_stream);
   }
   std::cerr.flush();
@@ -50,3 +53,22 @@ int main(int argc, char **argv) {
   return rc;
 }
 // End function main
+
+int main(int argc, char *argv[]) {
+  int rc = -1;
+#ifndef _LIBCPP_NO_EXCEPTIONS
+  try {
+#endif
+    rc = file_filter_main(argc, argv);
+#ifndef _LIBCPP_NO_EXCEPTIONS
+  }
+  catch (std::exception& e)
+  {
+    std::cerr << prog_name << ": ERROR:"
+              << " Exception thrown during program execution."
+              << " " << e.what()
+              << std::endl;
+  }
+#endif
+  return rc;
+}

--- a/tests/lib_tests.cc
+++ b/tests/lib_tests.cc
@@ -79,6 +79,20 @@ TEST(lib_tests, FilePath_Absolute) {
   EXPECT_EQ(file_path.DirName(), current_dir);
 }
 
+TEST(lib_tests, FilePath_Absolute_NotFound) {
+  std::string file_name = "/aa/bcdef/gg.txt";
+
+  TraceEntryExit t("lib_tests", "FilePath_Absolute_NotFound", file_name, true);
+
+  std::cout << std::endl << "File = " << file_name << std::endl;
+
+  auto file_path = FilePath(file_name);
+  EXPECT_FALSE(file_path.Exists()) << "File " << file_path.to_string() << " should not exist.";
+
+  EXPECT_EQ(file_path.FName(), "gg.txt");
+  EXPECT_EQ(file_path.DirName(), "/aa/bcdef");
+}
+
 TEST(lib_tests, TextBox) {
   TraceEntryExit t("lib_tests", "TextBox", true);
 


### PR DESCRIPTION
Rename `test_filter.exe` to `file_filter.exe`

Catch and report any exceptions thrown from the file_filter main program.

Show `gcc` version info in build environment info dump.

Use quotes around cmake test command arguments.

Add test case `lib_tests::FilePath_Absolute_NotFound`