### PR TITLE
Field initialization + copy constructors

### DIFF
--- a/libsrc/TraceEntryExit.cc
+++ b/libsrc/TraceEntryExit.cc
@@ -61,18 +61,27 @@ TraceEntryExit::TraceEntryExit(
 
 TraceEntryExit::~TraceEntryExit() {
   if (alwaysLog || logEntryExits) {
-    TRACE_EXIT(this->className, this->functionName, this->args);
+#if !defined(_LIBCPP_NO_EXCEPTIONS)
+	try {
+#endif
+	  TRACE_EXIT(this->className, this->functionName, this->args);
+#if !defined(_LIBCPP_NO_EXCEPTIONS)
+	}
+	catch (...) {
+	  std::cerr << "ERROR during TRACE_EXIT" << std::endl;
+	}
+#endif
   }
 }
 
 bool TraceEntryExit::SetLogging(bool new_trace_level) {
-  bool old_logEntryExits = logEntryExits;
+  const bool old_logEntryExits = logEntryExits;
   logEntryExits = new_trace_level;
   return old_logEntryExits;
 }
 
 TraceLevelOverride TraceLevelOverride::SetLogging(bool new_trace_level) {
-  bool old_trace_level = TraceEntryExit::SetLogging(new_trace_level);
+  const bool old_trace_level = TraceEntryExit::SetLogging(new_trace_level);
   return TraceLevelOverride(old_trace_level);
 }
 

--- a/libsrc/TraceEntryExit.h
+++ b/libsrc/TraceEntryExit.h
@@ -13,13 +13,16 @@ static const std::string BLANK_STR = std::string(BLANK);
  * class to allow temporarily override the tracing level.
  */
 class TraceLevelOverride {
-private:
   bool previous;
 
 public:
   static TraceLevelOverride SetLogging(bool new_trace_level);
 
   explicit TraceLevelOverride(bool old_trace_level);
+
+  TraceLevelOverride(const TraceLevelOverride& other) = default;
+	
+  TraceLevelOverride& operator=(const TraceLevelOverride& other) = default;
 
   virtual ~TraceLevelOverride();
 };
@@ -34,18 +37,19 @@ public:
  *  if the flag `logEntryExits` is set.
  */
 class TraceEntryExit {
-private:
   static bool logEntryExits; // If true, then entry and exit trace will be logged.
 
   const std::string &className;
   const std::string &functionName;
   const std::string &args;
 
-  bool alwaysLog;
+  bool alwaysLog = false;
 
 public:
   constexpr static const char *EntryPrefix = ">>>> Enter ";
   constexpr static const char *Exit_Prefix = "<<<< Exit_ ";
+
+  TraceEntryExit(const TraceEntryExit& other) = default;
 
   /**
    * Constructor: TraceEntryExit

--- a/libsrc/filter.cc
+++ b/libsrc/filter.cc
@@ -12,9 +12,9 @@ int IFilter::main_loop() {
   for (;;)  // Loop forever, until breakout condition is hit.
   {
 
-#ifndef _LIBCPP_NO_EXCEPTIONS
-    try {
-#endif // _LIBCPP_NO_EXCEPTIONS
+#if !defined(_LIBCPP_NO_EXCEPTIONS)
+	try {
+#endif
 
       p->start();
       while (p->read()) {
@@ -23,8 +23,8 @@ int IFilter::main_loop() {
       }
       return p->result();  // Exit loop
 
-#ifndef _LIBCPP_NO_EXCEPTIONS
-    }
+#if !defined(_LIBCPP_NO_EXCEPTIONS)
+	}
     catch (IFilter::ERetry &m) {
       std::cerr << m.message() << std::endl;
       int i = p->retry();
@@ -36,7 +36,7 @@ int IFilter::main_loop() {
       std::cerr << "ERROR: Fatal filter error" << std::endl;
       return -10;  // Exit loop
     }
-#endif // _LIBCPP_NO_EXCEPTIONS
+#endif
 
   } // End forever loop
   // Not reached.


### PR DESCRIPTION
Initialize `alwaysLog` field.

Add copy constructors for `TraceEntryExit` and `TraceLevelOverride`.

Add try-catch protection against any problems from TRACE_EXIT function.