### PR TITLE
Cleanup and simplify FilePath code.

### DIFF
--- a/libsrc/FilePath.cc
+++ b/libsrc/FilePath.cc
@@ -6,22 +6,22 @@
 #include "fileutil.h"
 
 
-FilePath::FilePath(const std::string &path)
-    : FilePath(path.c_str()) {
+FilePath::FilePath(const char *file_path)
+    : FilePath(std::string(file_path)) {
 }
 
-FilePath::FilePath(const char *path) {
+FilePath::FilePath(const std::string &file_path) {
   // Split file name into components
 
-  fileName = FileUtils::basename(path);
-  dirName = FileUtils::dirname(path);
+  fileName = FileUtils::basename(file_path);
+  dirName = FileUtils::dirname(file_path);
 
   if (dirName.empty() || dirName == ".") {
     // No directory specified - so use current.
     dirName = FileUtils::GetCurrentDirectory();
   }
 
-  fileExists = FileUtils::IsFileReadable(path);
+  fileExists = FileUtils::IsFileReadable(file_path);
 }
 // End FilePath constructor //
 
@@ -31,10 +31,9 @@ FilePath::FilePath(const char *path) {
  * @return Return the full path name, which will be of the form /path/to/filename
  */
 std::string FilePath::FullName() const {
-  const std::string & file_sep = FileUtils::DirSeparator();
   std::stringstream ss;
   if (fileExists) {
-    ss << dirName << file_sep << fileName;
+	ss << dirName << FileUtils::DirSeparator() << fileName;
   } else {
     ss << "**Non-existent:" << fileName << "**";
   }

--- a/libsrc/FilePath.h
+++ b/libsrc/FilePath.h
@@ -16,15 +16,15 @@ protected:
 public:
   /**
    * Constructor for FilePath object.
-   * @param path - The path location for this file.
+   * @param file_path - The path location for this file.
    */
-  explicit FilePath(const std::string &path);
+  explicit FilePath(const std::string &file_path);
 
   /**
    * Constructor for FilePath object.
-   * @param path - The path location for this file.
+   * @param file_path - The path location for this file.
    */
-  explicit FilePath(const char *file_name);
+  explicit FilePath(const char *file_path);
 
   /**
    * Copy constructor for FilePath object.

--- a/libsrc/TraceEntryExit.h
+++ b/libsrc/TraceEntryExit.h
@@ -39,9 +39,9 @@ public:
 class TraceEntryExit {
   static bool logEntryExits; // If true, then entry and exit trace will be logged.
 
-  const std::string &className;
-  const std::string &functionName;
-  const std::string &args;
+  const std::string className;
+  const std::string functionName;
+  const std::string args;
 
   bool alwaysLog = false;
 

--- a/tests/blist_tests.cc
+++ b/tests/blist_tests.cc
@@ -8,7 +8,13 @@
 #include "../blist.h"
 #include "../libsrc/proginfo.h"
 
-std::string ProgInfo::Name = "blist_tests";
+class blist_tests : public ::testing::Test
+{
+public:
+  blist_tests() {
+    ProgInfo::Name = "blist_tests";
+  }
+};
 
 TEST(blist_tests, Params) {
   blist_params params{};

--- a/tests/file_filter_tests.cc
+++ b/tests/file_filter_tests.cc
@@ -10,7 +10,16 @@
 
 #include "../libsrc/filter.h"
 #include "../libsrc/FilePath.h"
+#include "../libsrc/proginfo.h"
 #include "../libsrc/TraceEntryExit.h"
+
+class file_filter_tests : public ::testing::Test
+{
+public:
+  file_filter_tests() {
+    ProgInfo::Name = "file_filter_tests";
+  }
+};
 
 TEST(file_filter_tests, ReadLines) {
   TraceEntryExit t("file_filter_tests", "ReadLines", true);

--- a/tests/lib_tests.cc
+++ b/tests/lib_tests.cc
@@ -14,6 +14,14 @@
 
 #define DEBUG
 
+class lib_tests : public ::testing::Test
+{
+public:
+  lib_tests() {
+    ProgInfo::Name = "lib_tests";
+  }
+};
+
 TEST(lib_tests, TraceLevelOverride) {
   TraceEntryExit t("lib_tests", "TraceLevelOverride", true);
 


### PR DESCRIPTION
Cleanup and simplify FilePath code.

- Use `std::string` as the canonical for of `FilePath` input.

- Add test class initialization blocks.