### PR TITLE
[LGTM] Fix error cpp/potentially-dangerous-function

### DIFF
--- a/libsrc/File.cc
+++ b/libsrc/File.cc
@@ -73,7 +73,9 @@ File::~File() {
 std::string File::ModificationDate() {
   time_t timestamp = FileUtils::FileCreationTimestamp(this->FullName());
 
-  auto modTime = std::string(std::asctime(std::localtime(&timestamp)));
+  struct tm time;
+  char time_str[25];
+  auto modTime = std::string(asctime_r(localtime_r(&timestamp, &time), time_str));
 
   // Clean any non-printable characters.
   for (size_t i = 0; i < modTime.length(); i++) {

--- a/libsrc/File.cc
+++ b/libsrc/File.cc
@@ -73,9 +73,14 @@ File::~File() {
 std::string File::ModificationDate() {
   time_t timestamp = FileUtils::FileCreationTimestamp(this->FullName());
 
+  #ifdef _MSC_VER
+  char * asctime_str = asctime(localtime(&timestamp));
+  #else
   struct tm time;
   char time_str[25];
-  auto modTime = std::string(asctime_r(localtime_r(&timestamp, &time), time_str));
+  char * asctime_str = asctime_r(localtime_r(&timestamp, &time), time_str);
+  #endif
+  auto modTime = std::string(asctime_str);
 
   // Clean any non-printable characters.
   for (size_t i = 0; i < modTime.length(); i++) {


### PR DESCRIPTION
Use of a standard library function that is not thread-safe.

https://lgtm.com/rules/2154840805/

Query pack: com.lgtm/cpp-queries
Query ID: cpp/potentially-dangerous-function
Language: C/C++
Severity: Warning
Tags: reliability security external/cwe/cwe-676

The time related functions such as `gmtime` fill data into a `tm` struct or char array in shared memory and then returns a pointer to that memory. If the function is called from multiple places in the same program, and especially if it is called from multiple threads in the same program, then the calls will overwrite each other's data.

- Use local buffers for reading asctime / localtime values.