### PR TITLE
Shellscript updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@
 # *.ipr
 
 # CMake
-cmake-build-*/
+cmake-build*/
 
 # Mongo Explorer plugin
 .idea/**/mongoSettings.xml

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 
-BLD_DIR=build
+CMD_DIR=$(dirname "$0")
 
-mkdir -p "${BLD_DIR}" && pushd "${BLD_DIR}" || return
+BLD_DIR=${CMD_DIR}/cmake-build
+
+mkdir -p "${BLD_DIR}" && pushd "${BLD_DIR}" || exit 1
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+set -o pipefail
 
 echo "---- cmake generate ----"
-set -x
 cmake .. &&
   echo "---- cmake build ----" &&
+  set -x &&
   cmake --build . "$@"

--- a/clean.sh
+++ b/clean.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
-BLD_DIR=build
+CMD_DIR=$(dirname "$0")
+
+BLD_DIR=${CMD_DIR}/cmake-build
 
 rm -fR "${BLD_DIR}"

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-BLD_DIR=build
+CMD_DIR=$(dirname "$0")
 
-pushd "${BLD_DIR}" || return
+BLD_DIR=${CMD_DIR}/cmake-build
+
+pushd "${BLD_DIR}" || exit 1
 
 ctest --output-on-failure "$@"


### PR DESCRIPTION
- Use `cmake-build` directory.
- Always resolve `cmake-build` directory relative to repo root.
- Exit `build.sh` script immediately if a command exits with a non-zero status.