### PR TITLE
Test-GetModificationDate

### DIFF
--- a/libsrc/TextBox.h
+++ b/libsrc/TextBox.h
@@ -34,10 +34,10 @@ public:
   explicit TextBox(const std::vector<std::string>& text_lines, BoxStyle box_type = STANDARD, char box_char = '*');
 
   // Copy constructors.
-  TextBox(const TextBox&) = default;
+  TextBox(const TextBox&)            = default;
   TextBox& operator=(const TextBox&) = default;
   // Move constructors.
-  TextBox(TextBox&&) = default;
+  TextBox(TextBox&&)            = default;
   TextBox& operator=(TextBox&&) = default;
 
   ~TextBox() = default;

--- a/libsrc/TraceEntryExit.h
+++ b/libsrc/TraceEntryExit.h
@@ -18,10 +18,10 @@ public:
   explicit TraceLevelOverride(bool old_trace_level);
 
   // Copy constructors.
-  TraceLevelOverride(const TraceLevelOverride&) = default;
+  TraceLevelOverride(const TraceLevelOverride&)            = default;
   TraceLevelOverride& operator=(const TraceLevelOverride&) = default;
   // Move constructors.
-  TraceLevelOverride(TraceLevelOverride&&) = default;
+  TraceLevelOverride(TraceLevelOverride&&)            = default;
   TraceLevelOverride& operator=(TraceLevelOverride&&) = default;
 
   virtual ~TraceLevelOverride();
@@ -50,10 +50,10 @@ public:
   constexpr static std::string_view Exit_Prefix = "<<<< Exit_ ";
 
   // Copy constructors for File object.
-  TraceEntryExit(const TraceEntryExit&) = default;
+  TraceEntryExit(const TraceEntryExit&)            = default;
   TraceEntryExit& operator=(const TraceEntryExit&) = delete;
   // Move constructors for File object.
-  TraceEntryExit(TraceEntryExit&&) = default;
+  TraceEntryExit(TraceEntryExit&&)            = default;
   TraceEntryExit& operator=(TraceEntryExit&&) = delete;
 
   /**

--- a/libsrc/fileutil.cc
+++ b/libsrc/fileutil.cc
@@ -34,10 +34,7 @@ std::string FileUtils::GetModificationDate(const std::filesystem::path& file_pat
 #endif
 
   // Clean any non-printable characters.
-  for (size_t i = 0; i < time_str_raw.size(); i++) {
-    if (time_str_raw[i] == '\0') {
-      break;
-    }
+  for (size_t i = 0; i < time_str_raw.size() && time_str_raw[i] != '\0'; i++) {
     if (!isprint(time_str_raw[i])) {
       time_str_raw[i] = ' ';
     }

--- a/libsrc/fileutil.cc
+++ b/libsrc/fileutil.cc
@@ -1,13 +1,33 @@
 #include "fileutil.h"
 
 #include <array>
+#include <chrono>
 #include <cstring>
+#include <ctime>
+#include <stdexcept>
 
 // #define EXTRA_DEBUG
 
 #if defined(EXTRA_DEBUG)
 #include <iostream>
 #endif
+
+bool FileUtils::IsFileReadable(const std::filesystem::path& file_path)
+{
+  if (!std::filesystem::exists(file_path)) {
+    return false;
+  }
+  auto status = std::filesystem::status(file_path);
+  return (status.permissions() & std::filesystem::perms::owner_read) != std::filesystem::perms::none;
+}
+
+std::filesystem::file_time_type FileUtils::FileCreationTimestamp(const std::filesystem::path& file_path)
+{
+  if (!std::filesystem::exists(file_path)) {
+    throw std::invalid_argument("File not found: " + file_path.lexically_normal().string());
+  }
+  return std::filesystem::last_write_time(file_path);
+}
 
 std::string FileUtils::GetModificationDate(const std::filesystem::path& file_path)
 {
@@ -47,3 +67,26 @@ std::string FileUtils::GetModificationDate(const std::filesystem::path& file_pat
   return modTime;
 }
 // End Member function ModificationDate
+
+std::string FileUtils::basename(const std::filesystem::path& file_path)
+{
+  std::filesystem::path file_name;
+  if (!file_path.empty()) {
+    file_name = file_path.filename();
+  }
+  if (file_name.empty()) {
+    return "";
+  }
+  return file_name.lexically_normal().generic_string();
+}
+std::string FileUtils::dirname(const std::filesystem::path& file_path)
+{
+  std::filesystem::path dir_path;
+  if (!file_path.empty()) {
+    dir_path = std::filesystem::path{file_path}.remove_filename();
+  }
+  if (dir_path.empty()) {
+    return ".";
+  }
+  return dir_path.lexically_normal().generic_string();
+}

--- a/libsrc/fileutil.cc
+++ b/libsrc/fileutil.cc
@@ -1,6 +1,7 @@
 #include "fileutil.h"
 
-#include <string.h>
+#include <array>
+#include <cstring>
 
 // #define EXTRA_DEBUG
 
@@ -21,28 +22,28 @@ std::string FileUtils::GetModificationDate(const std::filesystem::path& file_pat
   timestamp       = std::chrono::system_clock::to_time_t(time_point);
 #endif
 
-  struct tm time = {};
-  char      time_str[26];
+  struct tm time         = {};
+  auto      time_str_raw = std::array<char, 26>();
 
 #if defined(_MSC_VER)
   localtime_s(&time, &timestamp);
-  asctime_s(time_str, sizeof time_str, &time);
+  asctime_s(time_str_raw.data(), time_str_raw.size(), &time);
 #else
   localtime_r(&timestamp, &time);
-  asctime_r(&time, time_str);
+  asctime_r(&time, time_str_raw.data());
 #endif
 
   // Clean any non-printable characters.
-  for (size_t i = 0; i < sizeof time_str; i++) {
-    if (time_str[i] == '\0') {
+  for (size_t i = 0; i < time_str_raw.size(); i++) {
+    if (time_str_raw[i] == '\0') {
       break;
     }
-    if (!isprint(time_str[i])) {
-      time_str[i] = ' ';
+    if (!isprint(time_str_raw[i])) {
+      time_str_raw[i] = ' ';
     }
   }
 
-  auto modTime = std::string(time_str, strnlen(time_str, sizeof time_str));
+  auto modTime = std::string(time_str_raw.data(), strnlen(time_str_raw.data(), time_str_raw.size()));
 #if defined(EXTRA_DEBUG)
   std::cerr << "[" << modTime << "]" << std::endl;
 #endif

--- a/libsrc/fileutil.h
+++ b/libsrc/fileutil.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <ctime>
 #include <filesystem>
+#include <stdexcept>
 #include <string>
 
 /**
@@ -31,6 +32,9 @@ public:
    */
   static std::filesystem::file_time_type FileCreationTimestamp(const std::filesystem::path& file_path)
   {
+    if (!std::filesystem::exists(file_path)) {
+      throw std::invalid_argument("File not found: " + file_path.lexically_normal().string());
+    }
     return std::filesystem::last_write_time(file_path);
   }
 

--- a/libsrc/fileutil.h
+++ b/libsrc/fileutil.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <chrono>
-#include <ctime>
 #include <filesystem>
-#include <stdexcept>
 #include <string>
 
 /**
@@ -16,27 +13,14 @@ public:
    * @param file_path - The file to be inspected.
    * @return Return TRUE if specified file exists and is readable.
    */
-  static bool IsFileReadable(const std::filesystem::path& file_path)
-  {
-    if (!std::filesystem::exists(file_path)) {
-      return false;
-    }
-    auto status = std::filesystem::status(file_path);
-    return (status.permissions() & std::filesystem::perms::owner_read) != std::filesystem::perms::none;
-  }
+  static bool IsFileReadable(const std::filesystem::path& file_path);
 
   /**
    * Function: FileCreationTimestamp
    * @param file_path - The file to be inspected.
    * @return Return creation timestamp of the specified file.
    */
-  static std::filesystem::file_time_type FileCreationTimestamp(const std::filesystem::path& file_path)
-  {
-    if (!std::filesystem::exists(file_path)) {
-      throw std::invalid_argument("File not found: " + file_path.lexically_normal().string());
-    }
-    return std::filesystem::last_write_time(file_path);
-  }
+  static std::filesystem::file_time_type FileCreationTimestamp(const std::filesystem::path& file_path);
 
   /**
    * Get a printable string containing the modification date of a file.
@@ -45,26 +29,6 @@ public:
    */
   static std::string GetModificationDate(const std::filesystem::path& file_path);
 
-  static std::string basename(const std::filesystem::path& file_path)
-  {
-    std::filesystem::path file_name;
-    if (!file_path.empty()) {
-      file_name = file_path.filename();
-    }
-    if (file_name.empty()) {
-      return "";
-    }
-    return file_name.lexically_normal().generic_string();
-  }
-  static std::string dirname(const std::filesystem::path& file_path)
-  {
-    std::filesystem::path dir_path;
-    if (!file_path.empty()) {
-      dir_path = std::filesystem::path{file_path}.remove_filename();
-    }
-    if (dir_path.empty()) {
-      return ".";
-    }
-    return dir_path.lexically_normal().generic_string();
-  }
+  static std::string basename(const std::filesystem::path& file_path);
+  static std::string dirname(const std::filesystem::path& file_path);
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ TARGET_LINK_LIBRARIES(${TEST_EXE}
     ${LIB_NAME}
     )
 
-ADD_TEST(NAME run_blist_tests
+ADD_TEST(NAME ${LIB_NAME}_tests
         COMMAND $<TARGET_FILE:${TEST_EXE}>
 )

--- a/tests/blist_tests.cc
+++ b/tests/blist_tests.cc
@@ -1,6 +1,6 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
-#pragma ide diagnostic   ignored "cert-err58-cpp"
+#pragma ide diagnostic ignored "cert-err58-cpp"
 #endif
 
 #include "gtest/gtest.h"

--- a/tests/file_filter_tests.cc
+++ b/tests/file_filter_tests.cc
@@ -1,6 +1,6 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
-#pragma ide diagnostic   ignored "cert-err58-cpp"
+#pragma ide diagnostic ignored "cert-err58-cpp"
 #endif
 
 #include "gtest/gtest.h"

--- a/tests/lib_tests.cc
+++ b/tests/lib_tests.cc
@@ -10,7 +10,7 @@
 #include "../libsrc/TraceEntryExit.h"
 #include "../libsrc/fileutil.h"
 
-static const std::string prog_name = "file_filter_tests";
+static const std::string prog_name = "lib_tests";
 
 TEST(lib_tests, TraceLevelOverride)
 {
@@ -106,6 +106,17 @@ TEST(lib_tests, file_utils_dirname)
   EXPECT_EQ(FileUtils::dirname("c:\\windows\\path.ext"), "c:/windows/");
   EXPECT_EQ(FileUtils::dirname("c:\\windows\\no_filename\\"), "c:/windows/no_filename/");
 #endif
+}
+
+TEST(lib_tests, file_utils_GetModificationDate)
+{
+  std::filesystem::path file = "cmake_install.cmake";
+  EXPECT_TRUE(std::filesystem::exists(file.string()));
+
+  auto str = FileUtils::GetModificationDate(file);
+
+  std::cout << "GetModificationDate " << file << " = [" << str << "]" << std::endl;
+  EXPECT_FALSE(str.empty());
 }
 
 #if defined(__clang__)

--- a/tests/lib_tests.cc
+++ b/tests/lib_tests.cc
@@ -1,6 +1,6 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
-#pragma ide diagnostic   ignored "cert-err58-cpp"
+#pragma ide diagnostic ignored "cert-err58-cpp"
 #endif
 
 #include "gtest/gtest.h"

--- a/tests/lib_tests.cc
+++ b/tests/lib_tests.cc
@@ -111,12 +111,19 @@ TEST(lib_tests, file_utils_dirname)
 TEST(lib_tests, file_utils_GetModificationDate)
 {
   std::filesystem::path file = "cmake_install.cmake";
-  EXPECT_TRUE(std::filesystem::exists(file.string()));
+  EXPECT_TRUE(std::filesystem::exists(file));
 
   auto str = FileUtils::GetModificationDate(file);
 
   std::cout << "GetModificationDate " << file << " = [" << str << "]" << std::endl;
   EXPECT_FALSE(str.empty());
+}
+
+TEST(lib_tests, file_utils_GetModificationDate_file_not_found)
+{
+  std::filesystem::path file = "no-file.non";
+  EXPECT_FALSE(std::filesystem::exists(file));
+  EXPECT_THROW(FileUtils::GetModificationDate(file), std::invalid_argument);
 }
 
 #if defined(__clang__)


### PR DESCRIPTION
- Add initial test case for `FileUtils::GetModificationDate` function.

- Add file-not-found test case for function `FileUtils::GetModificationDate`
 
- Use std::array rather than char*

- Keep fileutils implementation code separate from header file.
