### PR TITLE
ci builds matrix OS versions

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, ubuntu-20.04]
+        os: [macos-11, macos-12, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, macos-13, macos-14, ubuntu-20.04, ubuntu-22.04]
+        os: [ macos-11, macos-12, ubuntu-20.04, ubuntu-22.04 ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,10 +9,15 @@ env:
   Install_Directory: cmake-install
 
 jobs:
-  build-windows:
-    name: Build-Windows
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-2019, windows-2022 ]
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+
+    name: Build-${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
runs-on:
- macos-11, macos-12
- ubuntu-20.04, ubuntu-22.04
- windows-2019, windows-2022

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners