### PR TITLE
Restrict GITHUB_TOKEN to read-only access in GH Actions jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 # Dependabot checking for updated versions of github-actions
 
 # To get started with Dependabot version updates, you'll need to specify which

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -3,6 +3,9 @@ name: Build-CI
 
 on: pull_request
 
+permissions:
+  actions: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,6 +3,9 @@ name: Build-Windows
 
 on: pull_request
 
+permissions:
+  actions: read
+
 env:
   Build_Configuration: Release
   Build_Directory: cmake-build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # We must fetch at least the immediate parents so that if this is a pull request then we can checkout the head
+          # We must fetch at least the immediate parents
+          # so that if this is a pull request then we can checkout the head
           fetch-depth: 2
 
       # If this run was triggered by a pull request event, then checkout
@@ -38,7 +39,8 @@ jobs:
       # Command-line programs to run using the OS shell.
       # https://git.io/JvXDl
 
-      # If the Autobuild fails above, remove it and uncomment the following three lines and modify them (or add more)
+      # If the Autobuild fails above, remove it
+      # and uncomment the following three lines and modify them (or add more)
       # to build your code if your project uses a compiled language.
 
       #- run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,9 @@ name: CodeQL
 
 on: pull_request
 
+permissions:
+  actions: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,6 +8,9 @@ name: Lint Code Base
 # Run the linter job for all pull requests
 on: pull_request
 
+permissions:
+  actions: read
+
 jobs:
   build:
     name: Lint Code Base


### PR DESCRIPTION
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
