### PR TITLE
gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain
+
+# Declare files that will always have UNIX LF line endings on checkout.
+*.sh text eol=lf
+
+# Declare files that will always have Windows CRLF line endings on checkout.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.tar binary
+*.tgz binary
+*.gz binary
+*.zip binary
+*.exe binary
+*.snappy binary


### PR DESCRIPTION
- Add .gitattributes file to ensure correct line endings in *.sh / *.cmd scripts on Linux / Windows.